### PR TITLE
✨ feat(tox): bump deps inside tox.toml substitutions

### DIFF
--- a/src/bump_deps_index/_loaders/tox_toml.py
+++ b/src/bump_deps_index/_loaders/tox_toml.py
@@ -4,7 +4,7 @@ import re
 from functools import cached_property
 from pathlib import Path
 from tomllib import load as load_toml
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, ClassVar
 
 from bump_deps_index._spec import PkgType
 
@@ -12,8 +12,11 @@ from ._base import Loader
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
+    from typing import TypeAlias
 
-_Section = dict[str, object]
+    TomlValue: TypeAlias = "str | int | float | bool | list[TomlValue] | dict[str, TomlValue] | None"
+
+_NESTED: frozenset[str] = frozenset({"env", "env_base"})
 
 
 class ToxToml(Loader):
@@ -50,27 +53,55 @@ class ToxToml(Loader):
     def load(self, filename: Path, *, pre_release: bool | None) -> Iterator[tuple[str, PkgType, bool]]:
         pre = False if pre_release is None else pre_release
         with filename.open("rb") as file_handler:
-            cfg = load_toml(file_handler)
-        yield from self._generate(cfg.get("requires", []), pkg_type=PkgType.PYTHON, pre_release=pre)
+            cfg: dict[str, TomlValue] = load_toml(file_handler)
+        yield from self._generate(self._specs(cfg.get("requires")), pkg_type=PkgType.PYTHON, pre_release=pre)
         yield from self._extract_deps(cfg, pre_release=pre)
 
-    def _extract_deps(self, cfg: dict[str, Any], *, pre_release: bool) -> Iterator[tuple[str, PkgType, bool]]:
+    def _extract_deps(self, cfg: dict[str, TomlValue], *, pre_release: bool) -> Iterator[tuple[str, PkgType, bool]]:
         for key, section in cfg.items():
             if not isinstance(section, dict):
                 continue
-            yield from self._deps_from_section(cast("_Section", section), pre_release=pre_release)
-            if key == "env":
-                for env_section in cast("dict[str, _Section]", section).values():
-                    yield from self._deps_from_section(env_section, pre_release=pre_release)
+            yield from self._deps_from_section(section, pre_release=pre_release)
+            if key in _NESTED:
+                for env_section in section.values():
+                    if isinstance(env_section, dict):
+                        yield from self._deps_from_section(env_section, pre_release=pre_release)
 
-    def _deps_from_section(self, section: _Section, *, pre_release: bool) -> Iterator[tuple[str, PkgType, bool]]:
-        deps: object = section.get("deps")
-        if isinstance(deps, list):
-            yield from self._generate(
-                [d for d in cast("list[str]", deps) if not d.startswith("-")],
-                pkg_type=PkgType.PYTHON,
-                pre_release=pre_release,
-            )
+    def _deps_from_section(
+        self, section: dict[str, TomlValue], *, pre_release: bool
+    ) -> Iterator[tuple[str, PkgType, bool]]:
+        yield from self._generate(self._specs(section.get("deps")), pkg_type=PkgType.PYTHON, pre_release=pre_release)
+
+    @classmethod
+    def _specs(cls, value: TomlValue) -> list[str]:
+        """
+        Collect requirement strings from a tox ``requires``/``deps`` value.
+
+        tox native TOML lets a list hold inline-table substitutions alongside plain strings. A spec can only live in
+        the branches a substitution may fall back to: ``if`` (``then``/``else``), ``posargs``/``env``/``glob``
+        (``default``); these are followed transitively so nested substitutions are bumped too. ``ref`` points at
+        another config key bumped where it is defined, so it carries no inline spec. Flag entries (``-r ...``) and
+        ``{...}`` references are skipped, matching the tox.ini loader.
+        """
+        found: list[str] = []
+        cls._collect(value, found)
+        return found
+
+    @classmethod
+    def _collect(cls, value: TomlValue, found: list[str]) -> None:
+        if isinstance(value, str):
+            if value and value[0] not in {"-", "{"}:
+                found.append(value)
+        elif isinstance(value, list):
+            for item in value:
+                cls._collect(item, found)
+        elif isinstance(value, dict):
+            replace = value.get("replace")
+            if replace == "if":
+                cls._collect(value.get("then"), found)
+                cls._collect(value.get("else"), found)
+            elif replace in {"posargs", "env", "glob"}:
+                cls._collect(value.get("default"), found)
 
 
 __all__ = [

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -189,6 +189,88 @@ def test_tox_toml_deps(capsys: pytest.CaptureFixture[str], mocker: MockerFixture
     assert dest.read_text() == dedent(toml).lstrip()
 
 
+def test_tox_toml_substitutions(capsys: pytest.CaptureFixture[str], mocker: MockerFixture, tmp_path: Path) -> None:
+    # a deps list may hold tox native-TOML substitution tables; bump the deps reachable through every
+    # fallback branch (if then/else, posargs/env/glob default), transitively for nested substitutions,
+    # while leaving ref targets (bumped where defined) and substitution metadata (name/pattern) untouched
+    mapping = {n: f"{n}>=1" for n in ("alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel")}
+    mocker.patch(
+        "bump_deps_index._run.update_spec",
+        side_effect=lambda _, __, ___, spec, ____, _____: mapping[spec],
+    )
+    dest = tmp_path / "tox.toml"
+    toml = """
+    requires = ["alpha"]
+
+    [env_run_base]
+    deps = [
+      { replace = "if", condition = "true", then = ["bravo"], else = ["charlie"], extend = true },
+      { replace = "posargs", default = ["delta"], extend = true },
+      { replace = "env", name = "X", default = "echo" },
+      { replace = "glob", pattern = "*.txt", default = ["foxtrot"], extend = true },
+      { replace = "ref", of = ["env_run_base", "deps"] },
+    ]
+
+    [env_base.matrix]
+    factors = [["py312", "py313"]]
+    deps = [
+      { replace = "if", condition = "true", then = [
+        { replace = "posargs", default = ["golf"], extend = true },
+      ], extend = true },
+    ]
+
+    [env.type]
+    deps = ["hotel"]
+    """
+    dest.write_text(dedent(toml).lstrip())
+    run(Options(index_url="https://pypi.org/simple", npm_registry="", pkgs=[], filenames=[dest], pre_release="no"))
+
+    out, err = capsys.readouterr()
+    assert not err
+    assert set(out.splitlines()) == {f"{n} -> {n}>=1" for n in mapping}
+
+    toml = """
+    requires = ["alpha>=1"]
+
+    [env_run_base]
+    deps = [
+      { replace = "if", condition = "true", then = ["bravo>=1"], else = ["charlie>=1"], extend = true },
+      { replace = "posargs", default = ["delta>=1"], extend = true },
+      { replace = "env", name = "X", default = "echo>=1" },
+      { replace = "glob", pattern = "*.txt", default = ["foxtrot>=1"], extend = true },
+      { replace = "ref", of = ["env_run_base", "deps"] },
+    ]
+
+    [env_base.matrix]
+    factors = [["py312", "py313"]]
+    deps = [
+      { replace = "if", condition = "true", then = [
+        { replace = "posargs", default = ["golf>=1"], extend = true },
+      ], extend = true },
+    ]
+
+    [env.type]
+    deps = ["hotel>=1"]
+    """
+    assert dest.read_text() == dedent(toml).lstrip()
+
+
+def test_tox_toml_malformed_env_entry(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    # a non-table value under env/env_base is not a real environment; skip it instead of crashing
+    dest = tmp_path / "tox.toml"
+    toml = """
+    [env]
+    broken = "not-a-table"
+    """
+    dest.write_text(dedent(toml).lstrip())
+    run(Options(index_url="https://pypi.org/simple", npm_registry="", pkgs=[], filenames=[dest], pre_release="no"))
+
+    out, err = capsys.readouterr()
+    assert not err
+    assert not set(out.splitlines())
+    assert dest.read_text() == dedent(toml).lstrip()
+
+
 def test_tox_toml_multiline(capsys: pytest.CaptureFixture[str], mocker: MockerFixture, tmp_path: Path) -> None:
     mapping = {"pytest>=7.0": "pytest>=8.0", "coverage>=6.0": "coverage>=7.0"}
     mocker.patch(


### PR DESCRIPTION
The `tox.toml` loader only bumped plain string entries, so a dependency tucked inside a native-TOML substitution table was silently left stale. 📦 Modern `tox.toml` files lean on these tables for conditional and parametrized dependency sets, and `env_base` templates were skipped entirely, leaving whole swaths of a config untouched by a bump.

Loading now walks `requires` and `deps` recursively and collects specs from every branch a substitution can fall back to: `if` (`then`/`else`) and `posargs`/`env`/`glob` (`default`), nested cases included. ✨ A `ref` is deliberately left alone because its target is bumped where it is actually defined, and substitution metadata such as a `glob` pattern or an `env` variable name is never mistaken for a requirement. Section scanning also descends into `env_base` templates so their deps are covered alongside `env` sections.

The same pass tightens typing: a recursive `TomlValue` alias replaces `Any` and `object` across the loader, so `isinstance` narrowing carries the parsed structure end to end without casts. Behavior for plain string deps is unchanged; the new coverage is purely additive.