### PR TITLE
👷 ci: test against Python 3.15

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,6 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         py:
+          - "3.15t"
+          - "3.15"
           - "3.14t"
           - "3.14"
           - "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
@@ -124,6 +125,9 @@ lint.preview = true
 [tool.codespell]
 builtin = "clear,usage,en-GB_to_en-US"
 count = true
+
+[tool.pyproject-fmt]
+max_supported_python = "3.15"
 
 [tool.ty]
 environment.python-version = "3.11"

--- a/tox.toml
+++ b/tox.toml
@@ -1,5 +1,5 @@
 requires = [ "tox>=4.30.3", "tox-uv>=1.28" ]
-env_list = [ "3.14", "3.13", "3.12", "3.11", "3.14t", "docs", "fix", "pkg_meta", "type" ]
+env_list = [ "3.15", "3.14", "3.13", "3.12", "3.11", "3.14t", "3.15t", "docs", "fix", "pkg_meta", "type" ]
 skip_missing_interpreters = true
 
 [env_run_base]


### PR DESCRIPTION
Python 3.15 is in beta. Testing against it now means breakage shows up here instead of in a bug report after the release. 🐍

The matrix in `check.yaml` and `env_list` in `tox.toml` both gain `3.15` and `3.15t`, matching how the repo already declares `3.14` and `3.14t`. No prerelease pin goes with them, since GitHub Actions and `uv` resolve the current 3.15 build on their own, so the same entries keep working through rc and final.

`pyproject.toml` gains the `Programming Language :: Python :: 3.15` classifier, and `[tool.pyproject-fmt] max_supported_python` moves to `3.15`. Without that second entry the hook strips the classifier as newer than the Python it knows, so the two go together. The entry comes back out once pyproject-fmt's own maximum catches up, the way the 3.13 one did. `requires-python` is unchanged and no version is dropped.