### PR TITLE
🐛 fix(tests): pin coverage core to ctrace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ ini_options.filterwarnings = [
 ini_options.verbosity_assertions = 2
 
 [tool.coverage]
+run.core = "ctrace"  # sysmon (3.14+ default) cannot record the per-test contexts we collect
 run.parallel = true
 run.plugins = [
   "covdefaults",


### PR DESCRIPTION
Tests fail on Python 3.14 and 3.15 (all platforms) with `coverage.exceptions.CoverageWarning: Dynamic contexts aren't supported with core=sysmon`.

Coverage 7.15 defaults to the `sysmon` core on 3.14+, and that core cannot record dynamic contexts. `pytest-cov`'s `--cov-context=test` calls `switch_context()` for every test, so each one emits a `no-sysmon-context` warning — and `filterwarnings = ["error"]` turns those into failures.

Pinning `run.core = "ctrace"` keeps the per-test contexts that `html.show_contexts` renders. Verified locally on 3.11, 3.12, 3.13, 3.14, 3.14t, 3.15 and 3.15t.

Unblocks #247.